### PR TITLE
feat: expose epoch, studio/agent addresses, and viewerUrl on Session

### DIFF
--- a/src/session/Session.ts
+++ b/src/session/Session.ts
@@ -69,11 +69,13 @@ export class Session {
   public readonly sessionId: string;
   /** Epoch number returned by the gateway. */
   public readonly epoch: number;
+  /** Studio contract address for this session. */
+  public readonly studioAddress: string;
+  /** Default agent wallet address for this session. */
+  public readonly agentAddress: string;
 
   private readonly gatewayUrl: string;
   private readonly apiKey: string | undefined;
-  private readonly studioAddress: string;
-  private readonly agentAddress: string;
   private readonly studioPolicyVersion: string;
   private readonly workMandateId: string;
   private readonly taskType: string;
@@ -110,7 +112,12 @@ export class Session {
    * Automatically generates `event_id`, `timestamp`, and chains `parent_event_ids`
    * from the previous event so the gateway can build a causal DAG.
    *
-   * @param opts - Event details. Only `summary` is required.
+   * @param opts.summary - Human-readable description of what happened (required).
+   * @param opts.event_type - Canonical event type (default: `"artifact_created"`).
+   * @param opts.metadata - Arbitrary key-value metadata attached to the event.
+   * @param opts.agent - Override the session-level agent for this event.
+   *   Pass `{ agent_address, role? }` to emit the event from a different agent.
+   *   Valid roles: `"worker"`, `"verifier"`, `"collaborator"`. Defaults to `"worker"`.
    * @throws Error if the gateway returns a non-2xx status.
    */
   async log(opts: SessionLogOptions): Promise<void> {
@@ -155,8 +162,9 @@ export class Session {
    *
    * Unknown step types fall back to `artifact_created`.
    *
-   * @param stepType - Friendly step name.
+   * @param stepType - Friendly step name (`"planning"`, `"implementing"`, `"testing"`, `"debugging"`, `"completing"`).
    * @param summary - What happened in this step.
+   * @param agent - Optional agent override for this event. Same as `log({ agent })`.
    */
   async step(stepType: string, summary: string, agent?: SessionAgentOverride): Promise<void> {
     const eventType = STEP_TYPE_MAP[stepType] ?? 'artifact_created';
@@ -167,11 +175,13 @@ export class Session {
    * Complete the session.
    *
    * Triggers the on-chain WorkSubmission workflow (if the gateway is configured for it)
-   * and returns `workflow_id` + `data_hash` for downstream verification/scoring.
+   * and returns the session result.
    *
-   * @param opts - Optional status (`"completed"` | `"failed"`) and summary.
-   * @returns `{ workflow_id, data_hash }` — both may be `null` if the gateway
-   *          workflow engine is not configured.
+   * @param opts.status - `"completed"` or `"failed"` (default: `"completed"`).
+   * @param opts.summary - Human-readable summary of the session outcome.
+   * @returns `{ workflow_id, data_hash, epoch }` — `workflow_id` and `data_hash`
+   *          may be `null` if the gateway workflow engine is not configured.
+   *          `epoch` is the epoch this session belongs to.
    * @throws Error if the gateway returns a non-2xx status.
    */
   async complete(

--- a/src/session/Session.ts
+++ b/src/session/Session.ts
@@ -73,6 +73,8 @@ export class Session {
   public readonly studioAddress: string;
   /** Default agent wallet address for this session. */
   public readonly agentAddress: string;
+  /** URL to view this session's Evidence DAG in the browser. */
+  public readonly viewerUrl: string;
 
   private readonly gatewayUrl: string;
   private readonly apiKey: string | undefined;
@@ -96,6 +98,7 @@ export class Session {
   }) {
     this.sessionId = opts.sessionId;
     this.epoch = opts.epoch;
+    this.viewerUrl = `${opts.gatewayUrl}/v1/sessions/${opts.sessionId}/viewer`;
     this.gatewayUrl = opts.gatewayUrl;
     this.apiKey = opts.apiKey;
     this.lastEventId = opts.lastEventId ?? null;

--- a/src/session/Session.ts
+++ b/src/session/Session.ts
@@ -48,6 +48,7 @@ export interface SessionLogOptions {
 export interface SessionCompleteResult {
   workflow_id: string | null;
   data_hash: string | null;
+  epoch: number;
 }
 
 /** Canonical event-type mappings for {@link Session.step}. */
@@ -66,6 +67,8 @@ const STEP_TYPE_MAP: Record<string, string> = {
 export class Session {
   /** Session ID returned by the gateway. */
   public readonly sessionId: string;
+  /** Epoch number returned by the gateway. */
+  public readonly epoch: number;
 
   private readonly gatewayUrl: string;
   private readonly apiKey: string | undefined;
@@ -87,8 +90,10 @@ export class Session {
     studioPolicyVersion: string;
     workMandateId: string;
     taskType: string;
+    epoch: number;
   }) {
     this.sessionId = opts.sessionId;
+    this.epoch = opts.epoch;
     this.gatewayUrl = opts.gatewayUrl;
     this.apiKey = opts.apiKey;
     this.lastEventId = opts.lastEventId ?? null;
@@ -177,12 +182,13 @@ export class Session {
     if (opts?.summary) body.summary = opts.summary;
 
     const data = await this.post<{
-      data: { workflow_id: string | null; data_hash: string | null };
+      data: { workflow_id: string | null; data_hash: string | null; epoch: number };
     }>(`/v1/sessions/${this.sessionId}/complete`, body);
 
     return {
       workflow_id: data.data?.workflow_id ?? null,
       data_hash: data.data?.data_hash ?? null,
+      epoch: data.data.epoch,
     };
   }
 

--- a/src/session/SessionClient.ts
+++ b/src/session/SessionClient.ts
@@ -69,8 +69,16 @@ export class SessionClient {
    * and complete the session. The gateway persists all events and constructs the
    * Evidence DAG automatically.
    *
-   * @param opts - Session creation parameters.
-   * @returns A live {@link Session} bound to the newly created session ID.
+   * The returned session exposes `session.sessionId`, `session.epoch`,
+   * `session.studioAddress`, and `session.agentAddress`.
+   *
+   * @param opts.studio_address - Studio contract address (required).
+   * @param opts.agent_address - Worker agent wallet address (required).
+   * @param opts.task_type - Task classification: `"feature"`, `"bugfix"`, `"refactor"`, etc. (default: `"general"`).
+   * @param opts.work_mandate_id - Work mandate identifier (default: `"generic-task"`).
+   * @param opts.studio_policy_version - Studio policy version (default: `"engineering-studio-default-v1"`).
+   * @param opts.session_id - Client-provided session ID. Server generates one if omitted.
+   * @returns A live {@link Session} bound to the newly created session ID and epoch.
    * @throws Error if the gateway returns a non-2xx status.
    */
   async start(opts: SessionStartOptions): Promise<Session> {

--- a/src/session/SessionClient.ts
+++ b/src/session/SessionClient.ts
@@ -87,7 +87,7 @@ export class SessionClient {
     const headers: Record<string, string> = { 'Content-Type': 'application/json' };
     if (this.apiKey) headers['X-API-Key'] = this.apiKey;
 
-    let data: { data: { session_id: string } };
+    let data: { data: { session_id: string; epoch: number } };
     try {
       const res = await axios({ method: 'POST', url, data: body, headers, timeout: 30_000 });
       data = res.data as typeof data;
@@ -112,6 +112,7 @@ export class SessionClient {
       studioPolicyVersion: opts.studio_policy_version ?? 'engineering-studio-default-v1',
       workMandateId: opts.work_mandate_id ?? 'generic-task',
       taskType: opts.task_type ?? 'general',
+      epoch: data.data.epoch,
     });
   }
 }

--- a/tests/Session.test.ts
+++ b/tests/Session.test.ts
@@ -22,6 +22,7 @@ function createSession(overrides?: Partial<ConstructorParameters<typeof Session>
     studioPolicyVersion: 'engineering-studio-default-v1',
     workMandateId: 'generic-task',
     taskType: 'general',
+    epoch: 18,
     ...overrides,
   });
 }
@@ -260,27 +261,41 @@ describe('Session', () => {
     });
   });
 
+  describe('epoch', () => {
+    it('should expose epoch from session creation', () => {
+      const session = createSession();
+      expect(session.epoch).toBe(18);
+    });
+
+    it('should expose epoch with custom value', () => {
+      const session = createSession({ epoch: 42 });
+      expect(session.epoch).toBe(42);
+    });
+  });
+
   describe('complete()', () => {
-    it('should complete session without affecting agent override behavior', async () => {
+    it('should return workflow_id, data_hash, and epoch', async () => {
       const session = createSession();
       mockedAxios.mockResolvedValue({
-        data: { data: { workflow_id: 'wf-123', data_hash: '0xabc' } },
+        data: { data: { workflow_id: 'wf-123', data_hash: '0xabc', epoch: 18 } },
       });
 
       const result = await session.complete({ summary: 'Done' });
 
       expect(result.workflow_id).toBe('wf-123');
       expect(result.data_hash).toBe('0xabc');
+      expect(result.epoch).toBe(18);
     });
 
     it('should return null values when gateway has no workflow engine', async () => {
       const session = createSession();
-      mockedAxios.mockResolvedValue({ data: { data: {} } });
+      mockedAxios.mockResolvedValue({ data: { data: { epoch: 18 } } });
 
       const result = await session.complete();
 
       expect(result.workflow_id).toBeNull();
       expect(result.data_hash).toBeNull();
+      expect(result.epoch).toBe(18);
     });
   });
 });

--- a/tests/integration.external.test.ts
+++ b/tests/integration.external.test.ts
@@ -6,12 +6,13 @@ const BASE_URL = 'https://gateway.chaoscha.in';
 
 describe('External SDK integration smoke', () => {
   it('supports external verifier workflow imports and pending work fetch', async () => {
-    const gateway = new GatewayClient({ baseUrl: BASE_URL });
+    const gateway = new GatewayClient({ baseUrl: BASE_URL, timeout: 3000 });
 
     try {
       const pending = await gateway.getPendingWork(STUDIO_ADDRESS);
       expect(Array.isArray(pending.data.work)).toBe(true);
     } catch (error) {
+      // Expected in CI: gateway not reachable
       expect(error).toBeDefined();
     }
 


### PR DESCRIPTION
## Summary

Exposes key session properties so integrators have immediate access to session context after `client.start()`, without extra API calls.

### New public properties on Session

| Property | Type | Description |
|---|---|---|
| `session.epoch` | `number` | Epoch number returned by the gateway |
| `session.studioAddress` | `string` | Studio contract address for this session |
| `session.agentAddress` | `string` | Default agent wallet address |
| `session.viewerUrl` | `string` | URL to view the Evidence DAG in the browser |

### Changes to `complete()` result

`SessionCompleteResult` now includes `epoch`:

```typescript
const { workflow_id, data_hash, epoch } = await session.complete();
```

### Usage

```typescript
const session = await client.start({ studio_address, agent_address, task_type: 'feature' });

console.log(session.epoch);         // 23
console.log(session.studioAddress); // '0xFA0795...'
console.log(session.agentAddress);  // '0x2c855f...'
console.log(session.viewerUrl);     // 'https://gateway.chaoscha.in/v1/sessions/sess_.../viewer'

const result = await session.complete({ summary: 'Done' });
console.log(result.epoch);          // 23 (matches session.epoch)
```

### Other changes

| File | Change |
|---|---|
| [`src/session/Session.ts`](https://github.com/gilbertsahumada/chaoschain-sdk-ts/blob/feature/epoch-to-session/src/session/Session.ts) | Added `epoch`, `studioAddress`, `agentAddress`, `viewerUrl` as public readonly properties. Improved JSDoc on `log()`, `step()`, and `complete()` for better IDE hover documentation |
| [`src/session/SessionClient.ts`](https://github.com/gilbertsahumada/chaoschain-sdk-ts/blob/feature/epoch-to-session/src/session/SessionClient.ts) | Parses `epoch` from gateway response and passes it to Session constructor. Improved JSDoc on `start()` |
| [`tests/Session.test.ts`](https://github.com/gilbertsahumada/chaoschain-sdk-ts/blob/feature/epoch-to-session/tests/Session.test.ts) | Added epoch tests (session property + complete result). Updated mock to include epoch |
| [`tests/integration.external.test.ts`](https://github.com/gilbertsahumada/chaoschain-sdk-ts/blob/feature/epoch-to-session/tests/integration.external.test.ts) | Fixed CI timeout: reduced GatewayClient timeout to 3s so the test doesn't exceed vitest's 5s limit when the production gateway is unreachable |

## Test plan

- [x] `npm run build` passes
- [x] All 334 tests pass, 0 failures
- [x] Tested against local gateway (localhost:3002): `session.epoch` = 23, `complete().epoch` = 23, epoch match confirmed
- [x] `viewerUrl` generates correct URL
- [x] Integration test fixed for CI (no more timeout)